### PR TITLE
Add LICENSE to package archives

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include click_completion *.j2
+LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 recursive-include click_completion *.j2
-LICENSE
+include LICENSE


### PR DESCRIPTION
I'm packaging click-completion for [conda-forge](https://conda-forge.org), which greatly prefers to have the actual license file in the package.

xref conda-forge/staged-recipes#5279