### PR TITLE
Pass along cli args to the complete functions of params

### DIFF
--- a/click_completion/core.py
+++ b/click_completion/core.py
@@ -110,7 +110,7 @@ def get_choices(cli, prog_name, args, incomplete):
                     break
     choices = []
     if optctx:
-        choices += [c if isinstance(c, tuple) else (c, None) for c in optctx.type.complete(ctx, incomplete)]
+        choices += [c if isinstance(c, tuple) else (c, None) for c in optctx.type.complete(ctx, args, incomplete)]
     else:
         for param in ctx.command.get_params(ctx):
             if (completion_configuration.complete_options or incomplete and not incomplete[:1].isalnum()) and isinstance(param, Option):

--- a/click_completion/patch.py
+++ b/click_completion/patch.py
@@ -36,7 +36,7 @@ def param_type_complete(self, ctx, incomplete):
     return []
 
 
-def choice_complete(self, ctx, incomplete):
+def choice_complete(self, ctx, args, incomplete):
     """Returns the completion results for click.core.Choice
 
     Parameters


### PR DESCRIPTION
Thanks for the helpful library!

I wanted to see if you'd be open to an API change for custom `complete()` methods on params. This makes it more similar to how click handles bash autocomplete, and it unblocks some features for our team.

---

Passing the args along to the `complete()` function of a param provides for
dynamic choices, similar to how the `autocompletion()` function documented by
click describes:

https://github.com/pallets/click/blob/d37ff750f4ba4aa5af6104f5fcaa5d81dcc227d6/docs/bashcomplete.rst#what-it-completes

This is a breaking change for existing `complete()` functions.

cc @JoshDrake-minted