### PR TITLE
Don't call compinit in Zsh completion code

### DIFF
--- a/click_completion/zsh.j2
+++ b/click_completion/zsh.j2
@@ -3,6 +3,5 @@ _{{prog_name}}() {
   eval $(env COMMANDLINE="${words[1,$CURRENT]}" {{complete_var}}=complete-zsh {% for k, v in extra_env.items() %} {{k}}={{v}}{% endfor %} {{prog_name}})
 }
 if [[ "$(basename -- ${(%):-%x})" != "_{{prog_name}}" ]]; then
-  autoload -U compinit && compinit
   compdef _{{prog_name}} {{prog_name}}
 fi


### PR DESCRIPTION
`compinit` resets the shell completion machinery, nuking any other dynamically added completions. It should be up to the user to call it once during his shell initialization.