### PR TITLE
Don't suggest hidden commands

### DIFF
--- a/click_completion/core.py
+++ b/click_completion/core.py
@@ -124,7 +124,8 @@ def get_choices(cli, prog_name, args, incomplete):
                         choices.append((opt, None))
         if isinstance(ctx.command, MultiCommand):
             for name in ctx.command.list_commands(ctx):
-                if match(name, incomplete):
+                command = ctx.command.get_command(ctx, name)
+                if match(name, incomplete) and not command.hidden:
                     choices.append((name, ctx.command.get_command_short_help(ctx, name)))
 
     for item, help in choices:

--- a/click_completion/core.py
+++ b/click_completion/core.py
@@ -126,7 +126,7 @@ def get_choices(cli, prog_name, args, incomplete):
             for name in ctx.command.list_commands(ctx):
                 command = ctx.command.get_command(ctx, name)
                 if match(name, incomplete) and not command.hidden:
-                    choices.append((name, ctx.command.get_command_short_help(ctx, name)))
+                    choices.append((name, command.get_short_help_str()))
 
     for item, help in choices:
         yield (item, help)


### PR DESCRIPTION
Fixes #21 

Additionally, we should probably use `click.Command.get_short_help_str`
> get_short_help_str(limit=45)
> Gets short help for the command or makes it by shortening the long help string.
