### PR TITLE
Escape backticks in help messages for zsh

### DIFF
--- a/click_completion/core.py
+++ b/click_completion/core.py
@@ -226,7 +226,7 @@ def do_zsh_complete(cli, prog_name):
         incomplete = ''
 
     def escape(s):
-        return s.replace('"', '""').replace("'", "''").replace('$', '\\$')
+        return s.replace('"', '""').replace("'", "''").replace('$', '\\$').replace('`', '\\`')
     res = []
     for item, help in get_choices(cli, prog_name, args, incomplete):
         if help:


### PR DESCRIPTION
As is, putting backticks in the short help of a command will cause zsh
to actually run that command when tab completing. This escapes those
properly so that the backtick literals are printed.