### PR TITLE
Add autocompletion callback for Options

### DIFF
--- a/click_completion/core.py
+++ b/click_completion/core.py
@@ -110,7 +110,10 @@ def get_choices(cli, prog_name, args, incomplete):
                     break
     choices = []
     if optctx:
-        choices += [c if isinstance(c, tuple) else (c, None) for c in optctx.type.complete(ctx, incomplete)]
+        choices += [c if isinstance(c, tuple) else(c, None) for c in optctx.type.complete(ctx, incomplete)]
+        if not choices and hasattr(optctx, 'autocompletion') and optctx.autocompletion is not None:
+            dynamic_completions = optctx.autocompletion(ctx=ctx, args=args, incomplete=incomplete)
+            choices += [c if isinstance(c, tuple) else (c, None) for c in dynamic_completions]
     else:
         for param in ctx.command.get_params(ctx):
             if (completion_configuration.complete_options or incomplete and not incomplete[:1].isalnum()) and isinstance(param, Option):


### PR DESCRIPTION
As explained  [here](https://click.palletsprojects.com/en/7.x/bashcomplete/?highlight=autocomplete) in the Click documentation, and implemented here: https://github.com/pallets/click/blob/93b1699cde5fbafe8a237f8f0d21c8f687b78f2f/click/_bashcomplete.py#L185, click `Parameter`s have an `autocompletion` argument that is currently not supported in `click-completion`.
This small addition rectifies that :)