### PR TITLE
Fix: filter hidden options

### DIFF
--- a/click_completion/core.py
+++ b/click_completion/core.py
@@ -114,6 +114,9 @@ def get_choices(cli, prog_name, args, incomplete):
     else:
         for param in ctx.command.get_params(ctx):
             if (completion_configuration.complete_options or incomplete and not incomplete[:1].isalnum()) and isinstance(param, Option):
+                # filter hidden click.Option
+                if getattr(param, 'hidden', False):
+                    continue
                 for opt in param.opts:
                     if match(opt, incomplete):
                         choices.append((opt, param.help))


### PR DESCRIPTION
Fix #31  
Options decorated with `hidden` should not be shown in the completion list :)