### PR TITLE
support colons in bash completion suggestions

### DIFF
--- a/click_completion/bash.j2
+++ b/click_completion/bash.j2
@@ -1,7 +1,7 @@
 _{{prog_name}}_completion() {
     local IFS=$'\t'
     _get_comp_words_by_ref -n : -w words -i cword
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+    COMPREPLY=( $( env COMP_WORDS="${words[*]}" \
                    COMP_CWORD=$cword \
 {%- for k, v in extra_env.items() %}
                    {{k}}={{v}} \

--- a/click_completion/bash.j2
+++ b/click_completion/bash.j2
@@ -1,11 +1,13 @@
 _{{prog_name}}_completion() {
     local IFS=$'\t'
+    _get_comp_words_by_ref -n : -w words -i cword
     COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
+                   COMP_CWORD=$cword \
 {%- for k, v in extra_env.items() %}
                    {{k}}={{v}} \
 {%- endfor %}
                    {{complete_var}}=complete-bash $1 ) )
+    __ltrim_colon_completions "${words[cword]}"
     return 0
 }
 


### PR DESCRIPTION
In the release version, completions containing colons won't work properly, because bash treats colons as word separators.

This PR uses a bash native function to make colons word characters. It also -- and this may be a matter of taste -- trims completions at the colon with another bash native function.