### PR TITLE
Fix context check in `zsh` completion template

### DIFF
--- a/click_completion/zsh.j2
+++ b/click_completion/zsh.j2
@@ -2,6 +2,8 @@
 _{{prog_name}}() {
   eval $(env COMMANDLINE="${words[1,$CURRENT]}" {{complete_var}}=complete-zsh {% for k, v in extra_env.items() %} {{k}}={{v}}{% endfor %} {{prog_name}})
 }
-if [[ "$(basename -- ${(%):-%x})" != "_{{prog_name}}" ]]; then
+if [[ $zsh_eval_context == *func ]]; then
+  _{{prog_name}} "$@"
+else
   compdef _{{prog_name}} {{prog_name}}
 fi


### PR DESCRIPTION
The old check worked correctly only when `eval`ing the template output. If the old template output was redirected to file and then `source`d or added to `$fpath` and picked up by `compinit`, completion would fail to start. This commit fixes that.
